### PR TITLE
[Feat] support npm scripts and OPTIONS redirect for mockserver

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 - Install node and npm (in case if you haven't).
 - Open terminal and navigate to the folder and execute below commands.
 - `npm install`
-- `mockserver -p 9000 -m mocks`
+- `npx mockserver -p 9000 -m mocks` OR `npm start 9000`
 - That should start a mock server and should show as below.
 - Mockserver serving mocks {verbose:true} under `mocks` at `http://localhost:9000`
 - change the port number in case if you are using `9000` for anything else.
@@ -11,5 +11,6 @@
 # Now you can do following API calls:
 
 - GET - `http://localhost:9000/goals` - gets all the goals
+- OPTIONS - `http://localhost:9000/goals` - verifies the request by redirect.
 - POST - `http://localhost:9000/goals` - creates a goal
 - DELETE - `http://localhost:9000/goals` - deletes a goal

--- a/mocks/goals/OPTIONS.mock
+++ b/mocks/goals/OPTIONS.mock
@@ -1,0 +1,9 @@
+HTTP/1.1 200 OK
+content-encoding: gzip
+transfer-encoding: chunked
+access-control-allow-origin: *
+access-control-allow-credentials: true
+strict-transport-security: max-age=31536000; includeSubDomains
+access-control-max-age: 3600
+access-control-allow-headers: expires,origin,language,pragma,accept,last-modified,x-xsrf-token,x-requested-with,content-type,location,cache-control,content-language
+access-control-allow-methods: POST, DELETE

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "mockable APIs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "mockserver -m mocks -p "
   },
   "keywords": [
     "mocker",


### PR DESCRIPTION
##  Context

Mockserver does not consist of `OPTIONS` method, which is required by `create-react-app` applications `fetch` API to verify all allowed methods before forwarding the request to the server.